### PR TITLE
Bump go to 1.24

### DIFF
--- a/app/go.mod
+++ b/app/go.mod
@@ -1,3 +1,3 @@
 module github.com/cloud-gov/cf-hello-worlds/go-hello
 
-go 1.22
+go 1.24

--- a/app/manifest.yml
+++ b/app/manifest.yml
@@ -5,7 +5,7 @@ applications:
     buildpacks:
       - go_buildpack
     env:
-      GOVERSION: "1.22"
+      GOVERSION: "1.24"
     processes:
       - type: web
         health-check-interval: 15


### PR DESCRIPTION
## Changes proposed in this pull request:

-
- This doesn't work on Cloud.gov anymore with 1.22
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Safe. Keeping up with the times.
